### PR TITLE
Suppress unnecessary deprecation warning for Ruby v3.1.

### DIFF
--- a/lib/rspec/parameterized/table_syntax.rb
+++ b/lib/rspec/parameterized/table_syntax.rb
@@ -9,7 +9,7 @@ require 'binding_of_caller'
 module RSpec
   module Parameterized
     module TableSyntax
-      if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create("3.2.0.rc1")
+      if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create('3.1.0')
         refine Object do
           import_methods TableSyntaxImplement
         end


### PR DESCRIPTION
I use Ruby v3.1 in RoR application.

A deprecation warning is output for each test run, but I assume that this warning has already been fixed and is unnecessary.

So, I have changed to use the new logic from Ruby v3.1.

```
root@b33a198a1459:/app# RAILS_ENV=test bundle e rspec spec/model/sample.rb                                      
/usr/local/bundle/gems/rspec-parameterized-table_syntax-1.0.0/lib/rspec/parameterized/table_syntax.rb:38: warning: Refinement#include is deprecated and will be removed in Ruby 3.2                                                                                                       
/usr/local/bundle/gems/rspec-parameterized-table_syntax-1.0.0/lib/rspec/parameterized/table_syntax.rb:42: warning: Refinement#include is deprecated and will be removed in Ruby 3.2                                                                                                       
/usr/local/bundle/gems/rspec-parameterized-table_syntax-1.0.0/lib/rspec/parameterized/table_syntax.rb:46: warning: Refinement#include is deprecated and will be removed in Ruby 3.2                                                                                                       
/usr/local/bundle/gems/rspec-parameterized-table_syntax-1.0.0/lib/rspec/parameterized/table_syntax.rb:50: warning: Refinement#include is deprecated and will be removed in Ruby 3.2                                                                                                       
/usr/local/bundle/gems/rspec-parameterized-table_syntax-1.0.0/lib/rspec/parameterized/table_syntax.rb:54: warning: Refinement#include is deprecated and will be removed in Ruby 3.2
/usr/local/bundle/gems/rspec-parameterized-table_syntax-1.0.0/lib/rspec/parameterized/table_syntax.rb:58: warning: Refinement#include is deprecated and will be removed in Ruby 3.2
...
```

ref: https://bugs.ruby-lang.org/issues/17429