### PR TITLE
Allow binding_of_caller to load under Ruby 4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in rspec-parameterized-table_syntax.gemspec
 gemspec
-
-# FIXME: Workaround for Ruby 4.0+
-# ref. https://github.com/banister/binding_of_caller/pull/90
-gem "binding_of_caller", github: "kivikakk/binding_of_caller", branch: "push-yrnnzolypxun"

--- a/lib/rspec/parameterized/table_syntax.rb
+++ b/lib/rspec/parameterized/table_syntax.rb
@@ -4,7 +4,25 @@ require "rspec/parameterized/table_syntax/version"
 require 'rspec/parameterized/table_syntax/table'
 require 'rspec/parameterized/table_syntax/table_syntax_implement'
 require "rspec/parameterized/core"
-require 'binding_of_caller'
+
+# FIXME: Monkey patch for Ruby 4.0+
+# ref. https://github.com/hanami/hanami-webconsole/pull/12
+if RUBY_ENGINE == "ruby"
+  # Skip binding_of_caller's version check and force it to load on Ruby 4.0.
+  #
+  # Remove this shim once https://github.com/banister/binding_of_caller/pull/90 is merged and a new
+  # release has been made.
+  require "binding_of_caller/version"
+  require "binding_of_caller/mri"
+
+  # Prevent a direct require to "binding_of_caller", which is no longer needed by this point, and
+  # which prints a misleading warning about it not supporting Ruby 4.0, which we've fixed ourselves
+  # via the above.
+  $LOADED_FEATURES << "binding_of_caller.rb"
+else
+  require "binding_of_caller"
+end
+# require 'binding_of_caller'
 
 module RSpec
   module Parameterized


### PR DESCRIPTION
 ref. 

* https://github.com/hanami/hanami-webconsole/pull/12
* https://github.com/banister/binding_of_caller/pull/90