### PR TITLE
Requires binding_of_caller v2+

### DIFF
--- a/lib/rspec/parameterized/table_syntax.rb
+++ b/lib/rspec/parameterized/table_syntax.rb
@@ -4,25 +4,7 @@ require "rspec/parameterized/table_syntax/version"
 require 'rspec/parameterized/table_syntax/table'
 require 'rspec/parameterized/table_syntax/table_syntax_implement'
 require "rspec/parameterized/core"
-
-# FIXME: Monkey patch for Ruby 4.0+
-# ref. https://github.com/hanami/hanami-webconsole/pull/12
-if RUBY_ENGINE == "ruby"
-  # Skip binding_of_caller's version check and force it to load on Ruby 4.0.
-  #
-  # Remove this shim once https://github.com/banister/binding_of_caller/pull/90 is merged and a new
-  # release has been made.
-  require "binding_of_caller/version"
-  require "binding_of_caller/mri"
-
-  # Prevent a direct require to "binding_of_caller", which is no longer needed by this point, and
-  # which prints a misleading warning about it not supporting Ruby 4.0, which we've fixed ourselves
-  # via the above.
-  $LOADED_FEATURES << "binding_of_caller.rb"
-else
-  require "binding_of_caller"
-end
-# require 'binding_of_caller'
+require 'binding_of_caller'
 
 module RSpec
   module Parameterized

--- a/rspec-parameterized-table_syntax.gemspec
+++ b/rspec-parameterized-table_syntax.gemspec
@@ -32,7 +32,7 @@ I was inspired by [udzura's mock](https://gist.github.com/1881139).}
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "binding_of_caller"
+  spec.add_dependency "binding_of_caller", ">= 2"
   spec.add_dependency "rspec-parameterized-core", ">= 2", "< 3"
 
   spec.add_development_dependency "rake"


### PR DESCRIPTION
https://github.com/banister/binding_of_caller/pull/90 was merged and [binding_of_caller v2.0.0](https://rubygems.org/gems/binding_of_caller/versions/2.0.0) was released.

Therefore, I reverted #22